### PR TITLE
Further Fixes for 5f36

### DIFF
--- a/index.js
+++ b/index.js
@@ -269,7 +269,10 @@ class Device {
     this.request_header = this.rm4Type ? new Buffer([0x04, 0x00]) : new Buffer([]);
     this.code_sending_header = this.rm4Type ? new Buffer([0xda, 0x00]) : new Buffer([]);
     //except 5f36 ¯\_(ツ)_/¯
-    if (deviceType == 0x5f36) {this.code_sending_header = new Buffer([0xd0, 0x00]);}
+    if (deviceType == 0x5f36) {
+      this.code_sending_header = new Buffer([0xd0, 0x00]);
+      this.request_header = new Buffer([0x04, 0x00]);
+    }
 
     this.on = this.emitter.on;
     this.emit = this.emitter.emit;


### PR DESCRIPTION
Modifies the Device.request_header for RM3 Mini D. In reference to [this issue](https://github.com/kiwi-cam/homebridge-broadlink-rm/issues/161).