### PR TITLE
Support use in Docker images/containers

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,9 +90,11 @@ class Broadlink extends EventEmitter {
 
     this.devices = {};
     this.sockets = [];
-    // The UDP port to listen on when discovering Broadlink devices
+    // The UDP port to listen on when discovering Broadlink devices. A value of 0 will use a randomly selected free port.
     this.discoveryPort = 0;
-    // The IP address range to broadcast for discovery. For container use the IP range of the host network (e.g. 192.168.0.255).
+    // The IP address range to broadcast for discovery. 
+    // When using the module within a (Docker) container use the IP range of the host's network 
+    // (e.g. On a Docker host with an IP of 192.168.0.21 use a value of 192.168.0.255).
     this.broadcastAddress = '255.255.255.255';
   }
 

--- a/index.js
+++ b/index.js
@@ -90,6 +90,10 @@ class Broadlink extends EventEmitter {
 
     this.devices = {};
     this.sockets = [];
+    // The UDP port to listen on when discovering Broadlink devices
+    this.discoveryPort = 0;
+    // The IP address range to broadcast for discovery. For container use the IP range of the host network (e.g. 192.168.0.255).
+    this.broadcastAddress = '255.255.255.255';
   }
 
   discover() {
@@ -110,7 +114,7 @@ class Broadlink extends EventEmitter {
       socket.on('listening', this.onListening.bind(this, socket, ipAddress));
       socket.on('message', this.onMessage.bind(this));
 
-      socket.bind(0, ipAddress);
+      socket.bind(this.discoveryPort, ipAddress);
     });
   }
 
@@ -189,7 +193,8 @@ class Broadlink extends EventEmitter {
     packet[0x20] = checksum & 0xff;
     packet[0x21] = checksum >> 8;
 
-    socket.sendto(packet, 0, packet.length, 80, '255.255.255.255');
+    if (log && debug) log(`\x1b[35m[DEBUG]\x1b[0m Broadcasting device discovery to IP range ${this.broadcastAddress}`);
+    socket.sendto(packet, 0, packet.length, 80, this.broadcastAddress);
   }
 
   onMessage (message, host) {

--- a/index.js
+++ b/index.js
@@ -96,8 +96,8 @@ class Broadlink extends EventEmitter {
     // When using the module within a (Docker) container use the IP range of the host's network 
     // (e.g. On a Docker host with an IP of 192.168.0.21 use a value of 192.168.0.255).
     this.broadcastAddress = '255.255.255.255';
-    // If you are using this module with Kubernetes set multicast to true to be able to find devices on the host network.
-    // This is needed as most Kubernetes distributions will not allow broadcast messages.
+    // If you are using this module with Kubernetes (or another container management system) set multicast to true to be able to find devices on the host's network.
+    // This is needed as most Kubernetes distributions do not suport broadcast messages as they consider UDP broadcasting to be a major network security risk.
     this.multicast = false;
   }
 
@@ -143,8 +143,8 @@ class Broadlink extends EventEmitter {
   onListening (socket, ipAddress) {
     const { debug, log } = this;
 
-    // Broadcase a multicast UDP message to let Broadlink devices know we're listening
     if(!this.multicast){
+      // Broadcase a multicast UDP message to let Broadlink devices know we're listening
       socket.setBroadcast(true);  
     }
 
@@ -202,8 +202,8 @@ class Broadlink extends EventEmitter {
 
     if(this.multicast){
       // Multicast mode
-      if (log && debug) log(`\x1b[35m[DEBUG]\x1b[0m Multicasting device discovery to IP range: ${multicastAddress}`);
       const ipRange = this.broadcastAddress.substring(0, this.broadcastAddress.lastIndexOf(".") + 1);
+      if (log && debug) log(`\x1b[35m[DEBUG]\x1b[0m Multicasting device discovery to IP range: ${ipRange + 'XXX'}`);
 
       for (let index = 1; index < 256; index++) {
         let multicastAddress = ipRange + index.toString();        

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kiwicam-broadlinkjs-rm",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "A Node.JS fork of broadlinkjs specifically intended for interacting with RM devices in homebridge-broadlink-rm",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR contains changes which support the use of kiwicam-broadlinkjs-rm within Docker images and containers.

In summary; the changes in this PR allow you to override the discovery mode (broadcast or multicast) for UDP device discovery, the UDP port and the IP range. 

==Background==

I use this module as a part of my personal smart home setup. I run a containerised version of [broadlink-mqtt-bridge](https://github.com/ben-kemister/broadlink-mqtt-bridge/tree/feature/improve-container-support) within a k3s (Kubernetes) cluster.

To use this module within a (Docker) container, without running a privileged container (which is not good security practice), you need to be able to set the discovery UDP port and the IP range to that of the container host.

Additionally to use this module in a Kubernetes cluster you need to use UDP multicast rather than broadcast, as most Kubernetes distributions considers UDP broadcasting to be a major network security risk.

The current defaults of 'kiwicam-broadlinkjs-rm' use a randomly selected UDP port and the 255.255.255.255 broadcast address, but these do not work when using the library in a Docker container, or in a Kubernetes cluster.

Lastly, great work on maintaining this library! I have found it very useful. Keep up the good work!