### PR TITLE
Consistenly assign Broadlink.devices keys with macAddress.toString('hex')

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ rm4DeviceTypes[parseInt(0x6070, 16)] = "Broadlink RM4 Mini C";
 rm4DeviceTypes[parseInt(0x62be, 16)] = "Broadlink RM4 Mini C";
 rm4DeviceTypes[parseInt(0x610f, 16)] = "Broadlink RM4 Mini C";
 rm4DeviceTypes[parseInt(0x6539, 16)] = "Broadlink RM4 Mini C";
+rm4DeviceTypes[parseInt(0x520d, 16)] = "Broadlink RM4 Mini C";
 rm4DeviceTypes[parseInt(0x648d, 16)] = "Broadlink RM4 Mini S";
 rm4DeviceTypes[parseInt(0x5216, 16)] = "Broadlink RM4 Mini";
 rm4DeviceTypes[parseInt(0x520c, 16)] = "Broadlink RM4 Mini";

--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ rm4DeviceTypes[parseInt(0x610f, 16)] = "Broadlink RM4 Mini C";
 rm4DeviceTypes[parseInt(0x6539, 16)] = "Broadlink RM4 Mini C";
 rm4DeviceTypes[parseInt(0x648d, 16)] = "Broadlink RM4 Mini S";
 rm4DeviceTypes[parseInt(0x5216, 16)] = "Broadlink RM4 Mini";
+rm4DeviceTypes[parseInt(0x520c, 16)] = "Broadlink RM4 Mini";
 rm4DeviceTypes[parseInt(0x2225, 16)] = 'Manual RM4 Device';
 
 // RM4 Devices (with RF support)
@@ -55,6 +56,7 @@ rm4PlusDeviceTypes[parseInt(0x6026, 16)] = "Broadlink RM4 Pro";
 rm4PlusDeviceTypes[parseInt(0x61a2, 16)] = "Broadlink RM4 Pro";
 rm4PlusDeviceTypes[parseInt(0x649b, 16)] = "Broadlink RM4 Pro";
 rm4PlusDeviceTypes[parseInt(0x653c, 16)] = "Broadlink RM4 Pro";
+rm4PlusDeviceTypes[parseInt(0x520b, 16)] = "Broadlink RM4 Pro";
 rm4PlusDeviceTypes[parseInt(0x6184, 16)] = "Broadlink RM4C Pro";
 rm4PlusDeviceTypes[parseInt(0x2227, 16)] = 'Manual RM4 Pro Device';
 

--- a/index.js
+++ b/index.js
@@ -217,7 +217,7 @@ class Broadlink extends EventEmitter {
   addDevice (host, macAddress, deviceType) {
     const { log, debug } = this;
 
-    if (this.devices[macAddress]) return;
+    if (this.devices[macAddress.toString('hex')]) return;
 
     const isHostObjectValid = (
       typeof host === 'object' &&
@@ -231,7 +231,7 @@ class Broadlink extends EventEmitter {
 
     // Mark is at not supported by default so we don't try to
     // create this device again.
-    this.devices[macAddress] = 'Not Supported';
+    this.devices[macAddress.toString('hex')] = 'Not Supported';
 
     // Ignore devices that don't support infrared or RF.
     if (unsupportedDeviceTypes[parseInt(deviceType, 16)]) return null;
@@ -252,7 +252,7 @@ class Broadlink extends EventEmitter {
     device.log = log;
     device.debug = debug;
 
-    this.devices[macAddress] = device;
+    this.devices[macAddress.toString('hex')] = device;
 
     // Authenticate the device and let others know when it's ready.
     device.on('deviceReady', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "kiwicam-broadlinkjs-rm",
-  "version": "0.9.1999999999scription": "A Node.JS fork of broadlinkjs specifically intended for interacting with RM devices in homebridge-broadlink-rm",
+  "version": "0.9.19",
+  "description": "A Node.JS fork of broadlinkjs specifically intended for interacting with RM devices in homebridge-broadlink-rm",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "kiwicam-broadlinkjs-rm",
-  "version": "0.9.18",
-  "description": "A Node.JS fork of broadlinkjs specifically intended for interacting with RM devices in homebridge-broadlink-rm",
+  "version": "0.9.1999999999scription": "A Node.JS fork of broadlinkjs specifically intended for interacting with RM devices in homebridge-broadlink-rm",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kiwicam-broadlinkjs-rm",
-  "version": "0.9.17",
+  "version": "0.9.18",
   "description": "A Node.JS fork of broadlinkjs specifically intended for interacting with RM devices in homebridge-broadlink-rm",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hi Cameron,

I'm a heavy user of [homebridge-broadlink-rm](https://github.com/kiwi-cam/homebridge-broadlink-rm), with 4 of those devices at home, and I had been struggling with auto device discoverability for a while. Your library always found 3 of my 4 devices, and not necessarily the same 3. Initially, I thought it was the broadlink hardware entering locked mode, but when using [python-broadlink](https://github.com/mjg59/python-broadlink) I always managed to find the 4 of them. So, I finally spent some time today to dig into it, and it seems that I found out the root cause.

Essentially, there is an expectation on the `onMessage()` handler that the key for `Broadlink.devices` will be generated as `macAddress.toString('hex')`, but during the `addDevice()` method we directly assign the buffer value as the key: `this.devices[macAddress] = device`

That, in itself, seems innocent enough. The check to prevent re-adding existing devices is wasted, since `macAddress.toString('hex') != String(macAddress)`, but the resulting Device object is the same.

Now, here's the interesting part, `String(macAddress)` can return the same string, for different buffer values. And that's exactly what was happening in my case. I had 2 devices, with 2 different mac addresses, that resulted in the same value when stringified. This script demonstrates the bug:

```node
const assert = require('node:assert').strict;

let macAStr = 'ec0bae9e9d8b'
let macBStr = 'ec0bae9eb0b4'

let macABuff = Buffer.from(macAStr, 'hex')
let macBBuff = Buffer.from(macBStr, 'hex')

let devices = {}
devices[macABuff] = macABuff
devices[macBBuff] = macBBuff

assert.strictEqual(macABuff, macABuff, "Buffer A value matches itself")
assert.strictEqual(macBBuff, macBBuff, "Buffer B value matches itself")
assert.notStrictEqual(macABuff, macBBuff, "Buffer A and B values are different")
assert.notStrictEqual(macABuff.toString('hex'), macBBuff.toString('hex'), "Buffer A and B .toString('hex') values are different")
assert.strictEqual(String(macABuff), String(macBBuff), "String(Buffer A) and String(Buffer B) values are the same!!!")
assert.strictEqual(Object.keys(devices).length, 1, "devices Object has only 1 key!")
assert.strictEqual(Object.keys(devices)[0], String(macABuff), "devices key matches String(macABuff)")
```

The PR simply ensures that broadlink.devices are assigned with `macAddress.toString('hex')`. That ensures the serialization is safe, and also prevents from re-adding devices that were already discovered. I've been trying this fix on my homebridge installation and has been working like a charm so far. Would be very grateful if you could merge it in, and include it in a future release of `homebridge-broadlink-rm`. Let me know if you need any modifications on the PR, add tests, etc.

Thank you very much for your software!